### PR TITLE
Fixed project generation

### DIFF
--- a/lib/phoenx/use_cases/generate_workspace.rb
+++ b/lib/phoenx/use_cases/generate_workspace.rb
@@ -37,8 +37,6 @@ module Phoenx
 				path = '.'
 			
 			end
-		
-			previous = Dir.pwd
 
 			Dir.chdir(path) do
 				
@@ -52,9 +50,6 @@ module Phoenx
 				generator = Phoenx::GenerateProject.new spec
 				generator.build
 			end
-			
-			# Monkey patch due to bug in Xcode 8 that prevents chdir to switch back to previous dir
-			Dir.cp_chdir previous
 		
 		end
 		

--- a/lib/phoenx/utilities/xcodeproj_utils.rb
+++ b/lib/phoenx/utilities/xcodeproj_utils.rb
@@ -13,7 +13,6 @@ module Phoenx
 		files.each do |path|
 			
 			groups = File.dirname(path).split("/")
-			groups.delete("..")
 			concate = ""
 				
 			groups.each do |g|
@@ -48,18 +47,10 @@ module Phoenx
 	
 	end
 	
-	def Phoenx.get_absolute_path(path)
-	
-		groups = File.dirname(path).split("/")
-		groups.delete("..")
-		return groups.join("/")
-	
-	end
-	
 	def Phoenx.get_or_add_file(project,file)
 	
 		filename = File.basename(file)
-		dir = Phoenx.get_absolute_path(file)	
+		dir = File.dirname(file)
 		
 		group = project.main_group.find_subpath(dir, false)
 		file_ref = group.find_file_by_path(filename)

--- a/phoenx.gemspec
+++ b/phoenx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.executables   << "phoenx"
 
-  spec.add_runtime_dependency "xcodeproj", "~> 1.3.2"
+  spec.add_runtime_dependency "xcodeproj", "~> 1.4.0"
   spec.add_runtime_dependency "colored", "~> 1.2"
   
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
* Removing `..` groups led to missing file references in the project. In particular referencing a xcconfig file in a parent directory led to a crash because the file path cannot be resolved (`generate_project.rb:82`). Reverted this change.
* The project generation failed with the newest Xcode version (8.2.1) before updating xcodeproj.

Merry Christmas 🎄 