### PR TITLE
Watch App / Extensions Support

### DIFF
--- a/lib/phoenx/constants.rb
+++ b/lib/phoenx/constants.rb
@@ -12,6 +12,8 @@ module Phoenx
 	FRAMEWORKS_ROOT 	= "Frameworks"
 	CONFIGURATION_ROOT 	= "Configuration"
 	XCTEST_EXTENSION 	= "xctest"
+	APP_EXTENSION 		= "app"
+	EXTENSION_EXTENSION = "appex"
 	
 	ATTRIBUTES_CODE_SIGN_ON_COPY 	= {"ATTRIBUTES" => ["CodeSignOnCopy"]}
 	ATTRIBUTES_PUBLIC_HEADERS 		= {"ATTRIBUTES" => [:Public]}

--- a/lib/phoenx/entities/scheme.rb
+++ b/lib/phoenx/entities/scheme.rb
@@ -4,6 +4,8 @@ module Phoenx
 		attr_accessor :name
 		attr_accessor :archive_configuration
 		attr_accessor :launch_configuration
+		attr_accessor :analyze_configuration
+		attr_accessor :profile_configuration
 		
 		def initialize(name, block)
 			@name = name

--- a/lib/phoenx/entities/target.rb
+++ b/lib/phoenx/entities/target.rb
@@ -42,10 +42,11 @@ module Phoenx
 	
 	class TestableTarget < AbstractTarget
 		attr_reader :test_targets
+		attr_reader :extensions
 		attr_reader :schemes
 		attr_accessor :version
 		attr_accessor :platform
-		attr_reader :target_type
+		attr_accessor :target_type
 		attr_accessor :sub_projects
 		attr_accessor :private_headers
 		attr_accessor :excluded_private_headers
@@ -61,6 +62,7 @@ module Phoenx
 		def initialize(name, type, platform, version)
 			super()
 			@test_targets = []
+			@extensions = []
 			@schemes = []
 			@name = name
 			@target_type = type
@@ -82,6 +84,11 @@ module Phoenx
 			@test_targets << target
 		end
 		
+		def extension(name, &block)
+			target = Phoenx::TestableTarget.new name, nil, nil, nil, &block
+			@extensions << target
+		end
+
 		def scheme(name, &block)
 			@schemes << Phoenx::Scheme.new(name, block)
 		end

--- a/lib/phoenx/entities/target.rb
+++ b/lib/phoenx/entities/target.rb
@@ -60,6 +60,7 @@ module Phoenx
 		attr_accessor :launch_configuration
 		attr_accessor :analyze_configuration
 		attr_accessor :profile_configuration
+		attr_accessor :code_coverage_enabled
 	
 		public
 		
@@ -83,6 +84,7 @@ module Phoenx
 			@launch_configuration = 'Debug'
 			@analyze_configuration = 'Debug'
 			@profile_configuration = 'Debug'
+			@code_coverage_enabled = false
 			yield(self)
 		end
 		

--- a/lib/phoenx/entities/target.rb
+++ b/lib/phoenx/entities/target.rb
@@ -56,6 +56,10 @@ module Phoenx
 		attr_accessor :excluded_public_headers
 		attr_accessor :umbrella_header
 		attr_accessor :module_name
+		attr_accessor :archive_configuration
+		attr_accessor :launch_configuration
+		attr_accessor :analyze_configuration
+		attr_accessor :profile_configuration
 	
 		public
 		
@@ -75,6 +79,10 @@ module Phoenx
 			@excluded_project_headers = []
 			@public_headers = []
 			@excluded_public_headers = []
+			@archive_configuration = 'Debug'
+			@launch_configuration = 'Debug'
+			@analyze_configuration = 'Debug'
+			@profile_configuration = 'Debug'
 			yield(self)
 		end
 		

--- a/lib/phoenx/entities/target.rb
+++ b/lib/phoenx/entities/target.rb
@@ -43,6 +43,7 @@ module Phoenx
 	class TestableTarget < AbstractTarget
 		attr_reader :test_targets
 		attr_reader :extensions
+		attr_reader :watch_apps
 		attr_reader :schemes
 		attr_accessor :version
 		attr_accessor :platform
@@ -68,6 +69,7 @@ module Phoenx
 			super()
 			@test_targets = []
 			@extensions = []
+			@watch_apps = []
 			@schemes = []
 			@name = name
 			@target_type = type
@@ -94,9 +96,14 @@ module Phoenx
 			@test_targets << target
 		end
 		
-		def extension(name, &block)
+		def extension_target(name, &block)
 			target = Phoenx::TestableTarget.new name, nil, nil, nil, &block
 			@extensions << target
+		end
+
+		def watch_target(name, type, platform, version, &block)
+			target = Phoenx::TestableTarget.new name, type, platform, version, &block
+			@watch_apps << target
 		end
 
 		def scheme(name, &block)

--- a/lib/phoenx/use_cases/generate_project.rb
+++ b/lib/phoenx/use_cases/generate_project.rb
@@ -39,6 +39,9 @@ module Phoenx
 				elsif target.target_type == :framework
 					builder = FrameworkTargetBuilder.new @project, target, @project_spec
 					builder.build
+				elsif target.target_type == :watch2_app
+					builder = Watch2TargetBuilder.new @project, target, @project_spec
+					builder.build
 				end
 			end
 		end

--- a/lib/phoenx/use_cases/generate_project.rb
+++ b/lib/phoenx/use_cases/generate_project.rb
@@ -39,9 +39,6 @@ module Phoenx
 				elsif target.target_type == :framework
 					builder = FrameworkTargetBuilder.new @project, target, @project_spec
 					builder.build
-				elsif target.target_type == :watch2_app
-					builder = Watch2TargetBuilder.new @project, target, @project_spec
-					builder.build
 				end
 			end
 		end

--- a/lib/phoenx/use_cases/generate_target.rb
+++ b/lib/phoenx/use_cases/generate_target.rb
@@ -19,9 +19,12 @@ module Phoenx
 			files = Phoenx.merge_files_array(@target_spec.support_files, @target_spec.excluded_support_files)
 			Phoenx.get_or_add_files(@project, files)
 		end
+
+		def clean_target
+			self.target.frameworks_build_phases.clear
+		end
 		
 		def add_frameworks_and_libraries
-			self.target.frameworks_build_phases.clear
 			# Add Framework dependencies
 			frameworks_group = @project.main_group.find_subpath(FRAMEWORKS_ROOT, true)
 			Phoenx.add_groups_for_files(@project,@target_spec.frameworks)
@@ -270,6 +273,7 @@ module Phoenx
 		def build
 			@schemes = []
 			puts ">> Target ".green + @target_spec.name.bold
+			self.clean_target
 			self.add_sources
 			Phoenx::Target::HeaderBuilder.new(@project, @target, @target_spec).build
 			self.add_resources
@@ -511,6 +515,7 @@ module Phoenx
 			@target.build_phases << @project.new(Xcodeproj::Project::PBXSourcesBuildPhase)
 			@target.build_phases << @project.new(Xcodeproj::Project::PBXFrameworksBuildPhase)
 			@target.build_phases << @project.new(Xcodeproj::Project::PBXResourcesBuildPhase)
+			self.clean_target
 			self.add_sources
 			self.add_config_files
 			self.add_frameworks_and_libraries

--- a/lib/phoenx/use_cases/generate_target.rb
+++ b/lib/phoenx/use_cases/generate_target.rb
@@ -21,6 +21,7 @@ module Phoenx
 		end
 		
 		def add_frameworks_and_libraries
+			self.target.frameworks_build_phases.clear
 			# Add Framework dependencies
 			frameworks_group = @project.main_group.find_subpath(FRAMEWORKS_ROOT, true)
 			Phoenx.add_groups_for_files(@project,@target_spec.frameworks)

--- a/lib/phoenx/use_cases/generate_target.rb
+++ b/lib/phoenx/use_cases/generate_target.rb
@@ -209,7 +209,7 @@ module Phoenx
 			# Generate main scheme
 			scheme = SaveableScheme.new @project_spec.project_file_name, @target_spec.name, false
 			scheme.configure_with_targets(self.target, @test_target)
-			scheme.test_action.code_coverage_enabled = true # TODO
+			scheme.test_action.code_coverage_enabled = @target_spec.code_coverage_enabled
 			self.configure_scheme(scheme, @target_spec)
 			
 			@schemes << scheme
@@ -246,7 +246,7 @@ module Phoenx
 			@target_spec.schemes.each do |s|
 				scheme = SaveableScheme.new @project_spec.project_file_name, s.name, false
 				scheme.configure_with_targets(self.target, @test_target)
-				scheme.test_action.code_coverage_enabled = true # TODO
+				scheme.test_action.code_coverage_enabled = @target_spec.code_coverage_enabled
 				self.configure_scheme(scheme, s)
 
 				@schemes << scheme


### PR DESCRIPTION
## ⚠️ External Requirements ⚠️ 
Depends on three PRs on the [CocoaPods/Xcodeproj](https://github.com/CocoaPods/Xcodeproj/pulls) project. All required changes are available via the `development` branch of the [cobi-bike/Xcodeproj](https://github.com/cobi-bike/Xcodeproj/tree/development) fork:
`gem "xcodeproj", :git => "git@github.com:cobi-bike/Xcodeproj.git", :branch => "development"`

## Changes
### Support for Embedded watchOS Apps
```ruby
Phoenx::Project.new do |spec|
  spec.target "App", :application, :ios, '10.0' do |target|
    target.watch_target "WatchApp", :watch2_app, :watchos, '4.1' do |watch_target|
      # Same configuration properties available as for the app target
      watch_target.extension_target "COBIWatchExtension" do |extension|
        # Same configuration properties available as for the watch target
      end
    end
  end
end
```

### Support for (Today) Extensions
Solves https://github.com/jensmeder/Phoenx/issues/26 @karstenlitsche 
```ruby
Phoenx::Project.new do |spec|
  spec.target "App", :application, :ios, '10.0' do |target|
    target.extension_target "COBITodayExtension" do |extension|
      # Same configuration properties available as for the app target
    end
  end
end
```

### Other Changes
* The Foundation framework is no longer added by default @karstenlitsche  (https://github.com/jensmeder/Phoenx/issues/41)
* Made configurations for the analyze and profile scheme action configurable (e.g. `scheme.analyze_configuration = "Release"`)
* Made code coverage support configurable (i.e. `target.code_coverage_enabled = true`) ⚠️ Breaking change, was on by default, now it's off by default
* Made scheme configuration option available for targets — these are applied to the default scheme that is created for every target (e.g. `target.archive_configuration = "Release"`)